### PR TITLE
Update typescript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "thread-loader": "^1.1.5",
     "ts-loader": "3.5.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.9.1",
+    "typescript": "^3.0.1",
     "webpack": "3.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I have had some compatibility issues, because vscode's linter was using a newer version of typescript. So I have had some ts lint warning show up in vscode, while they didnt in the nuxt cli. I updated the typescript version and it seems to work just fine now.